### PR TITLE
Fix the case where a reviewer is mentioned and a new review is created

### DIFF
--- a/app/controllers/github_events_controller.rb
+++ b/app/controllers/github_events_controller.rb
@@ -34,11 +34,7 @@ class GithubEventsController < ApplicationController
       review.approve if comment.approved?
     elsif comment.commenter == owner
       comment.parsed_body.mentions.each do |github_user|
-        if review = pull_request.reviews.find_by(github_user: github_user)
-          review.update_attribute(:status, :to_review)
-          next
-        end
-        pull_request.reviews.create(github_user: github_user)
+        pull_request.reviews.create_or_reset_for(github_user)
       end
     end
   end

--- a/app/controllers/github_events_controller.rb
+++ b/app/controllers/github_events_controller.rb
@@ -34,7 +34,7 @@ class GithubEventsController < ApplicationController
       review.approve if comment.approved?
     elsif comment.commenter == owner
       comment.parsed_body.mentions.each do |github_user|
-        pull_request.reviews.create_or_reset_for(github_user)
+        pull_request.reviews.find_or_create_by(github_user: github_user).update_attribute(:status, :to_review)
       end
     end
   end

--- a/app/controllers/github_events_controller.rb
+++ b/app/controllers/github_events_controller.rb
@@ -33,8 +33,12 @@ class GithubEventsController < ApplicationController
       review.reject if comment.rejected?
       review.approve if comment.approved?
     elsif comment.commenter == owner
-      comment.parsed_body.mentions.each do |username|
-        pull_request.reviews.create(github_user: username)
+      comment.parsed_body.mentions.each do |github_user|
+        if review = pull_request.reviews.find_by(github_user: github_user)
+          review.update_attribute(:status, :to_review)
+          next
+        end
+        pull_request.reviews.create(github_user: github_user)
       end
     end
   end

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -6,15 +6,7 @@ class PullRequest  < ActiveRecord::Base
   belongs_to :github_user
   belongs_to :repository
 
-  has_many :reviews do
-    def create(attributes)
-      if review = self.find_by(github_user: attributes[:github_user])
-        review.update_attribute(:status, :to_review)
-        return review
-      end
-      super
-    end
-  end
+  has_many :reviews
 
   def parse_body
     @parsed_body = Values::Body.new(body)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -6,7 +6,15 @@ class PullRequest  < ActiveRecord::Base
   belongs_to :github_user
   belongs_to :repository
 
-  has_many :reviews
+  has_many :reviews  do
+    def create_or_reset_for(github_user)
+      if review = self.find_by(github_user: github_user)
+        review.update_attribute(:status, :to_review)
+      else
+        self.create(github_user: github_user)
+      end
+    end
+  end
 
   def parse_body
     @parsed_body = Values::Body.new(body)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -6,7 +6,15 @@ class PullRequest  < ActiveRecord::Base
   belongs_to :github_user
   belongs_to :repository
 
-  has_many :reviews
+  has_many :reviews do
+    def create(attributes)
+      if review = self.find_by(github_user: attributes[:github_user])
+        review.update_attribute(:status, :to_review)
+        return review
+      end
+      super
+    end
+  end
 
   def parse_body
     @parsed_body = Values::Body.new(body)

--- a/app/models/pull_request.rb
+++ b/app/models/pull_request.rb
@@ -6,15 +6,7 @@ class PullRequest  < ActiveRecord::Base
   belongs_to :github_user
   belongs_to :repository
 
-  has_many :reviews  do
-    def create_or_reset_for(github_user)
-      if review = self.find_by(github_user: github_user)
-        review.update_attribute(:status, :to_review)
-      else
-        self.create(github_user: github_user)
-      end
-    end
-  end
+  has_many :reviews
 
   def parse_body
     @parsed_body = Values::Body.new(body)


### PR DESCRIPTION
As discussed IRL earlier today, when mentioning a github user in a PR that this user is already reviewing, a new review is created, which explains the double reviews that are seen in the Chrome extension. This PR fixes that by making sure that creating a review for a github user never creates a duplicate, but rather updates the existing one to have the status `to_review` if one already exists.

@sgnr, @gmalette can you check if the way I override `#create` in the `has_many` relation is legit please?